### PR TITLE
add support for downloading specific years, default to only latest year of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ You can choose which geographies you want.
 >>> census_data_downloader.download_usa("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
 ```
 
-And you can choose which years you want.
+And you can choose which years you want, or default to the latest release.
 
 ```
->>> census_data_downloader.download_states("<YOUR CENSUS API KEY>", years="2012", data_dir="./your-data-folder/")
->>> census_data_downloader.download_tracts("<YOUR CENSUS API KEY>", years="2012,2017", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_counties("<YOUR CENSUS API KEY>", years=2012, data_dir="./your-data-folder/")
+>>> census_data_downloader.download_counties("<YOUR CENSUS API KEY>", years=[2012,2017], data_dir="./your-data-folder/")
 >>> census_data_downloader.download_counties("<YOUR CENSUS API KEY>", years="all", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_counties("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
 ```
 
 That's it.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,30 @@ Import our module.
 >>> import census_data_downloader
 ```
 
-Download everything.
+Download and process the latest year of data for all supported tables and every geography.
 
 ```
 >>> census_data_downloader.download_everything("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
+```
+
+You can choose which geographies you want.
+
+```
+>>> census_data_downloader.download_nationwide("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_states("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_congressional_districts("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_counties("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_places("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_tracts("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_usa("<YOUR CENSUS API KEY>", data_dir="./your-data-folder/")
+```
+
+And you can choose which years you want.
+
+```
+>>> census_data_downloader.download_states("<YOUR CENSUS API KEY>", years="2012", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_tracts("<YOUR CENSUS API KEY>", years="2012,2017", data_dir="./your-data-folder/")
+>>> census_data_downloader.download_counties("<YOUR CENSUS API KEY>", years="all", data_dir="./your-data-folder/")
 ```
 
 That's it.

--- a/census_data_downloader/base.py
+++ b/census_data_downloader/base.py
@@ -37,7 +37,7 @@ class BaseDownloader(object):
             raise NotImplementedError("Census API key required. Pass it as the first argument.")
         self.source = source
         self.force = force
-        
+
         #
         # Allow custom years for data download, defaulting to most recent year
         #
@@ -56,15 +56,20 @@ class BaseDownloader(object):
             # Only accept years that will actually return data
             for year in self.year_list:
                 if year not in self.ALL_YEARS:
-                    raise NotImplementedError(f"ACS data only available for the years {self.ALL_YEARS[-1]}-{self.ALL_YEARS[0]}.")
+                    error_msg = ("ACS data only available for the years "
+                                 f"{self.ALL_YEARS[-1]}-{self.ALL_YEARS[0]}.")
+                    raise NotImplementedError(error_msg)
 
         # Default to latest year of data
-        elif years == None:
+        elif years is None:
             self.year_list = (self.ALL_YEARS[0],)
 
         # Handle the failure case
         else:
-            raise NotImplementedError("The `years` argument accepts a single int (e.g. 2012), a list of ints (e.g. [2012,2017]), or the string \"all\". You can leave it empty to download the latest year of data.")
+            error_msg = ("The `years` argument accepts a single int (e.g. 2012), "
+                         "a list of ints (e.g. [2012,2017]), or the string \"all\". "
+                         "You can leave it empty to download the latest year of data.")
+            raise NotImplementedError(error_msg)
 
         # Set the data directories
         if data_dir:

--- a/census_data_downloader/base.py
+++ b/census_data_downloader/base.py
@@ -38,16 +38,33 @@ class BaseDownloader(object):
         self.source = source
         self.force = force
         
-        # Allow custom years for data download
+        #
+        # Allow custom years for data download, defaulting to most recent year
+        #
+
+        # Accept "all" shortcut to download all years
         if years == "all":
             self.year_list = self.ALL_YEARS
-        elif years:
-            self.year_list = [int(year) for year in years.split(',')]
+
+        # Accept single int or list of ints representing years
+        elif isinstance(years, int) or isinstance(years, list):
+            if isinstance(years, int):
+                self.year_list = [years]
+            else:
+                self.year_list = [int(year) for year in years]
+
+            # Only accept years that will actually return data
             for year in self.year_list:
                 if year not in self.ALL_YEARS:
                     raise NotImplementedError(f"ACS data only available for the years {self.ALL_YEARS[-1]}-{self.ALL_YEARS[0]}.")
-        else:
+
+        # Default to latest year of data
+        elif years == None:
             self.year_list = (self.ALL_YEARS[0],)
+
+        # Handle the failure case
+        else:
+            raise NotImplementedError("The `years` argument accepts a single int (e.g. 2012), a list of ints (e.g. [2012,2017]), or the string \"all\". You can leave it empty to download the latest year of data.")
 
         # Set the data directories
         if data_dir:

--- a/census_data_downloader/base.py
+++ b/census_data_downloader/base.py
@@ -15,7 +15,7 @@ class BaseDownloader(object):
     Downloads and processes ACS tables from the Census API.
     """
     THIS_DIR = pathlib.Path(__file__).parent
-    YEAR_LIST = (
+    ALL_YEARS = (
         2017,
         2016,
         2015,
@@ -27,7 +27,7 @@ class BaseDownloader(object):
         2009
     )
 
-    def __init__(self, api_key=None, source="acs5", data_dir=None, force=False):
+    def __init__(self, api_key=None, source="acs5", years=None, data_dir=None, force=False):
         """
         Configuration.
         """
@@ -37,6 +37,17 @@ class BaseDownloader(object):
             raise NotImplementedError("Census API key required. Pass it as the first argument.")
         self.source = source
         self.force = force
+        
+        # Allow custom years for data download
+        if years == "all":
+            self.year_list = self.ALL_YEARS
+        elif years:
+            self.year_list = [int(year) for year in years.split(',')]
+            for year in self.year_list:
+                if year not in self.ALL_YEARS:
+                    raise NotImplementedError(f"ACS data only available for the years {self.ALL_YEARS[-1]}-{self.ALL_YEARS[0]}.")
+        else:
+            self.year_list = (self.ALL_YEARS[0],)
 
         # Set the data directories
         if data_dir:
@@ -157,7 +168,7 @@ class BaseDownloader(object):
         """
         Download and process data.
         """
-        for year in self.YEAR_LIST:
+        for year in self.year_list:
             # Get the raw table
             raw_table = self._get_raw_table(year, api_filter, csv_suffix)
 


### PR DESCRIPTION
OK this one's mildly opinionated. Adds a `years` arg to `BaseDownloader` and documents usage in the readme.

* You get the original behavior (grabbing every year of data) by passing `years="all"`
* You can pass a single year: `years="2014"`
* You can pass a comma-separated list of years: `years="2012,2017"`
* If you don't pass the `years` arg at all, the download defaults to the latest year available, per the ALL_YEARS tuple

You can hate hate hate if you want