### PR TITLE
Add geography limits

### DIFF
--- a/census_data_downloader/base.py
+++ b/census_data_downloader/base.py
@@ -26,6 +26,22 @@ class BaseDownloader(object):
         2010,
         2009
     )
+    GEO_LIST = (
+        "nationwide",
+        "state",
+        "congressionaldistrict",
+        "county",
+        "place",
+        "urbanarea",
+        "msa",
+        "csa",
+        "puma",
+        "aiannhhomeland",
+        "zcta",
+        "statelegislativedistrictupper",
+        "statelegislativedistrictlower",
+        "tract"
+    )
 
     def __init__(
         self,
@@ -96,6 +112,8 @@ class BaseDownloader(object):
         """
         Download nationwide data.
         """
+        if "nationwide" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "nationwide"
         api_filter = {'for': 'us:1'}
         geoid_function = lambda row: 1
@@ -105,6 +123,8 @@ class BaseDownloader(object):
         """
         Download data for all states.
         """
+        if "state" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "states"
         api_filter = {'for': 'state:*'}
         geoid_function = lambda row: row['state']
@@ -114,6 +134,8 @@ class BaseDownloader(object):
         """
         Download data for all Congressional districts.
         """
+        if "congressionaldistrict" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "congressionaldistricts"
         api_filter = {'for': 'congressional district:*'}
         geoid_function = lambda row: row['state'] + row['congressional district']
@@ -123,6 +145,8 @@ class BaseDownloader(object):
         """
         Download data for all counties.
         """
+        if "county" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "counties"
         api_filter = {'for': 'county:*'}
         geoid_function = lambda row: row['state'] + row['county']
@@ -132,6 +156,8 @@ class BaseDownloader(object):
         """
         Download data for all Census designated places.
         """
+        if "place" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "places"
         api_filter = {'for': 'place:*'}
         geoid_function = lambda row: row['state'] + row['place']
@@ -141,6 +167,8 @@ class BaseDownloader(object):
         """
         Download data for all Census tracts in the provided state.
         """
+        if "tract" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         state_obj = getattr(states, state.upper())
         csv_suffix = f"tracts_{state_obj.abbr.lower()}"
         api_filter = {
@@ -154,6 +182,8 @@ class BaseDownloader(object):
         """
         Download data for all Census upper legislative districts in the provided state.
         """
+        if "statelegislativedistrictupper" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         state_obj = getattr(states, state.upper())
         csv_suffix = f'statelegislativedistrictsupper_{state_obj.abbr.lower()}'
         api_filter = {
@@ -167,6 +197,8 @@ class BaseDownloader(object):
         """
         Download data for all Census lower legislative districts in the provided state.
         """
+        if "statelegislativedistrictlower" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         state_obj = getattr(states, state.upper())
         csv_suffix = f'statelegislativedistrictslower_{state_obj.abbr.lower()}'
         api_filter = {
@@ -180,6 +212,8 @@ class BaseDownloader(object):
         """
         Download data for all urban areas
         """
+        if "urbanarea" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "urbanarea"
         api_filter = {'for': 'urban area:*'}
         geoid_function = lambda row: row['urban area']
@@ -189,6 +223,8 @@ class BaseDownloader(object):
         """
         Download data for Metropolitian Statistical Areas.
         """
+        if "msa" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "msa"
         api_filter = {'for': 'metropolitan statistical area/micropolitan statistical area:*'}
         geoid_function = lambda row: row['metropolitan statistical area/micropolitan statistical area']
@@ -198,6 +234,8 @@ class BaseDownloader(object):
         """
         Download data for Combined Statistical Areas.
         """
+        if "csa" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "csa"
         api_filter = {'for': 'combined statistical area:*'}
         geoid_function = lambda row: row['combined statistical area']
@@ -207,6 +245,8 @@ class BaseDownloader(object):
         """
         Download data for Public Use Microdata Areas.
         """
+        if "puma" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "puma"
         api_filter = {'for': 'public use microdata area:*'}
         geoid_function = lambda row: row['public use microdata area']
@@ -216,6 +256,8 @@ class BaseDownloader(object):
         """
         Download data for American Indian home lands.
         """
+        if "aiannhhomeland" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "aiannhhomeland"
         api_filter = {'for': 'american indian area/alaska native area/hawaiian home land:*'}
         geoid_function = lambda row: row['american indian area/alaska native area/hawaiian home land']
@@ -225,6 +267,8 @@ class BaseDownloader(object):
         """
         Download data for Zip Code Tabulation Areas
         """
+        if "zcta" not in self.GEO_LIST:
+            raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "zcta"
         api_filter = {'for': 'zip code tabulation area:*'}
         geoid_function = lambda row: row['zip code tabulation area']
@@ -234,17 +278,28 @@ class BaseDownloader(object):
         """
         Download all datasets that provide full coverage for the entire country.
         """
-        self.download_nationwide()
-        self.download_states()
-        self.download_congressional_districts()
-        self.download_counties()
-        self.download_places()
-        self.download_urban_areas()
-        self.download_msas()
-        self.download_csas()
-        self.download_pumas()
-        self.download_aiann_homelands()
-        self.download_zctas()
+        if "nationwide" in self.GEO_LIST:
+            self.download_nationwide()
+        if "state" in self.GEO_LIST:
+            self.download_states()
+        if "congressionaldistrict" in self.GEO_LIST:
+            self.download_congressional_districts()
+        if "county" in self.GEO_LIST:
+            self.download_counties()
+        if "place" in self.GEO_LIST:
+            self.download_places()
+        if "urbanarea" in self.GEO_LIST:
+            self.download_urban_areas()
+        if "msa" in self.GEO_LIST:
+            self.download_msas()
+        if "csa" in self.GEO_LIST:
+            self.download_csas()
+        if "puma" in self.GEO_LIST:
+            self.download_pumas()
+        if "aiannhhomeland" in self.GEO_LIST:
+            self.download_aiann_homelands()
+        if "zcta" in self.GEO_LIST:
+            self.download_zctas()
 
     def download_everything(self):
         """
@@ -252,9 +307,12 @@ class BaseDownloader(object):
         """
         self.download_usa()
         for state in states.STATES:
-            self.download_tracts(state.abbr)
-            self.download_state_legislative_districts_upper(state.abbr)
-            self.download_state_legislative_districts_lower(state.abbr)
+            if "tract" in self.GEO_LIST:
+                self.download_tracts(state.abbr)
+            if "statelegislativedistrictupper" in self.GEO_LIST:
+                self.download_state_legislative_districts_upper(state.abbr)
+            if "statelegislativedistrictlower" in self.GEO_LIST:
+                self.download_state_legislative_districts_lower(state.abbr)
 
     def _download_tables(self, api_filter, csv_suffix, geoid_function):
         """

--- a/census_data_downloader/base.py
+++ b/census_data_downloader/base.py
@@ -29,17 +29,17 @@ class BaseDownloader(object):
     GEO_LIST = (
         "nationwide",
         "state",
-        "congressionaldistrict",
+        "congressional_district",
         "county",
         "place",
         "urbanarea",
         "msa",
         "csa",
         "puma",
-        "aiannhhomeland",
+        "aiannh_homeland",
         "zcta",
-        "statelegislativedistrictupper",
-        "statelegislativedistrictlower",
+        "state_legislative_district_upper",
+        "state_legislative_district_lower",
         "tract"
     )
 
@@ -134,7 +134,7 @@ class BaseDownloader(object):
         """
         Download data for all Congressional districts.
         """
-        if "congressionaldistrict" not in self.GEO_LIST:
+        if "congressional_district" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "congressionaldistricts"
         api_filter = {'for': 'congressional district:*'}
@@ -182,7 +182,7 @@ class BaseDownloader(object):
         """
         Download data for all Census upper legislative districts in the provided state.
         """
-        if "statelegislativedistrictupper" not in self.GEO_LIST:
+        if "state_legislative_district_upper" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         state_obj = getattr(states, state.upper())
         csv_suffix = f'statelegislativedistrictsupper_{state_obj.abbr.lower()}'
@@ -197,7 +197,7 @@ class BaseDownloader(object):
         """
         Download data for all Census lower legislative districts in the provided state.
         """
-        if "statelegislativedistrictlower" not in self.GEO_LIST:
+        if "state_legislative_district_lower" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         state_obj = getattr(states, state.upper())
         csv_suffix = f'statelegislativedistrictslower_{state_obj.abbr.lower()}'
@@ -212,7 +212,7 @@ class BaseDownloader(object):
         """
         Download data for all urban areas
         """
-        if "urbanarea" not in self.GEO_LIST:
+        if "urban_area" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "urbanarea"
         api_filter = {'for': 'urban area:*'}
@@ -282,13 +282,13 @@ class BaseDownloader(object):
             self.download_nationwide()
         if "state" in self.GEO_LIST:
             self.download_states()
-        if "congressionaldistrict" in self.GEO_LIST:
+        if "congressional_district" in self.GEO_LIST:
             self.download_congressional_districts()
         if "county" in self.GEO_LIST:
             self.download_counties()
         if "place" in self.GEO_LIST:
             self.download_places()
-        if "urbanarea" in self.GEO_LIST:
+        if "urban_area" in self.GEO_LIST:
             self.download_urban_areas()
         if "msa" in self.GEO_LIST:
             self.download_msas()
@@ -296,7 +296,7 @@ class BaseDownloader(object):
             self.download_csas()
         if "puma" in self.GEO_LIST:
             self.download_pumas()
-        if "aiannhhomeland" in self.GEO_LIST:
+        if "aiannh_homeland" in self.GEO_LIST:
             self.download_aiann_homelands()
         if "zcta" in self.GEO_LIST:
             self.download_zctas()
@@ -309,9 +309,9 @@ class BaseDownloader(object):
         for state in states.STATES:
             if "tract" in self.GEO_LIST:
                 self.download_tracts(state.abbr)
-            if "statelegislativedistrictupper" in self.GEO_LIST:
+            if "state_legislative_district_upper" in self.GEO_LIST:
                 self.download_state_legislative_districts_upper(state.abbr)
-            if "statelegislativedistrictlower" in self.GEO_LIST:
+            if "state_legislative_district_lower" in self.GEO_LIST:
                 self.download_state_legislative_districts_lower(state.abbr)
 
     def _download_tables(self, api_filter, csv_suffix, geoid_function):

--- a/census_data_downloader/base.py
+++ b/census_data_downloader/base.py
@@ -26,21 +26,32 @@ class BaseDownloader(object):
         2010,
         2009
     )
+
+    # All available geographies
+    # (Subclasses can override this)
     GEO_LIST = (
         "nationwide",
-        "state",
-        "congressional_district",
-        "county",
-        "place",
-        "urbanarea",
-        "msa",
-        "csa",
-        "puma",
-        "aiannh_homeland",
-        "zcta",
-        "state_legislative_district_upper",
-        "state_legislative_district_lower",
-        "tract"
+        "states",
+        "congressional_districts",
+        "counties",
+        "places",
+        "urban_areas",
+        "msas",
+        "csas",
+        "pumas",
+        "aiann_homelands",
+        "zctas",
+        "state_legislative_districts_upper",
+        "state_legislative_districts_lower",
+        "tracts"
+    )
+
+    # Geographies only available on a per-state level
+    # (Subclasses should not override this)
+    STATE_ONLY_GEOS = (
+        "tracts",
+        "state_legislative_districts_upper",
+        "state_legislative_districts_lower"
     )
 
     def __init__(
@@ -123,7 +134,7 @@ class BaseDownloader(object):
         """
         Download data for all states.
         """
-        if "state" not in self.GEO_LIST:
+        if "states" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "states"
         api_filter = {'for': 'state:*'}
@@ -134,7 +145,7 @@ class BaseDownloader(object):
         """
         Download data for all Congressional districts.
         """
-        if "congressional_district" not in self.GEO_LIST:
+        if "congressional_districts" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "congressionaldistricts"
         api_filter = {'for': 'congressional district:*'}
@@ -145,7 +156,7 @@ class BaseDownloader(object):
         """
         Download data for all counties.
         """
-        if "county" not in self.GEO_LIST:
+        if "counties" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "counties"
         api_filter = {'for': 'county:*'}
@@ -156,7 +167,7 @@ class BaseDownloader(object):
         """
         Download data for all Census designated places.
         """
-        if "place" not in self.GEO_LIST:
+        if "places" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "places"
         api_filter = {'for': 'place:*'}
@@ -167,7 +178,7 @@ class BaseDownloader(object):
         """
         Download data for all Census tracts in the provided state.
         """
-        if "tract" not in self.GEO_LIST:
+        if "tracts" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         state_obj = getattr(states, state.upper())
         csv_suffix = f"tracts_{state_obj.abbr.lower()}"
@@ -182,7 +193,7 @@ class BaseDownloader(object):
         """
         Download data for all Census upper legislative districts in the provided state.
         """
-        if "state_legislative_district_upper" not in self.GEO_LIST:
+        if "state_legislative_districts_upper" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         state_obj = getattr(states, state.upper())
         csv_suffix = f'statelegislativedistrictsupper_{state_obj.abbr.lower()}'
@@ -197,7 +208,7 @@ class BaseDownloader(object):
         """
         Download data for all Census lower legislative districts in the provided state.
         """
-        if "state_legislative_district_lower" not in self.GEO_LIST:
+        if "state_legislative_districts_lower" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         state_obj = getattr(states, state.upper())
         csv_suffix = f'statelegislativedistrictslower_{state_obj.abbr.lower()}'
@@ -212,7 +223,7 @@ class BaseDownloader(object):
         """
         Download data for all urban areas
         """
-        if "urban_area" not in self.GEO_LIST:
+        if "urban_areas" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "urbanarea"
         api_filter = {'for': 'urban area:*'}
@@ -223,7 +234,7 @@ class BaseDownloader(object):
         """
         Download data for Metropolitian Statistical Areas.
         """
-        if "msa" not in self.GEO_LIST:
+        if "msas" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "msa"
         api_filter = {'for': 'metropolitan statistical area/micropolitan statistical area:*'}
@@ -234,7 +245,7 @@ class BaseDownloader(object):
         """
         Download data for Combined Statistical Areas.
         """
-        if "csa" not in self.GEO_LIST:
+        if "csas" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "csa"
         api_filter = {'for': 'combined statistical area:*'}
@@ -245,7 +256,7 @@ class BaseDownloader(object):
         """
         Download data for Public Use Microdata Areas.
         """
-        if "puma" not in self.GEO_LIST:
+        if "pumas" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "puma"
         api_filter = {'for': 'public use microdata area:*'}
@@ -256,7 +267,7 @@ class BaseDownloader(object):
         """
         Download data for American Indian home lands.
         """
-        if "aiannhhomeland" not in self.GEO_LIST:
+        if "aiann_homelands" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "aiannhhomeland"
         api_filter = {'for': 'american indian area/alaska native area/hawaiian home land:*'}
@@ -267,7 +278,7 @@ class BaseDownloader(object):
         """
         Download data for Zip Code Tabulation Areas
         """
-        if "zcta" not in self.GEO_LIST:
+        if "zctas" not in self.GEO_LIST:
             raise NotImplementedError(f"Data only available for these geographies: {', '.join(self.GEO_LIST)}")
         csv_suffix = "zcta"
         api_filter = {'for': 'zip code tabulation area:*'}
@@ -278,41 +289,26 @@ class BaseDownloader(object):
         """
         Download all datasets that provide full coverage for the entire country.
         """
-        if "nationwide" in self.GEO_LIST:
-            self.download_nationwide()
-        if "state" in self.GEO_LIST:
-            self.download_states()
-        if "congressional_district" in self.GEO_LIST:
-            self.download_congressional_districts()
-        if "county" in self.GEO_LIST:
-            self.download_counties()
-        if "place" in self.GEO_LIST:
-            self.download_places()
-        if "urban_area" in self.GEO_LIST:
-            self.download_urban_areas()
-        if "msa" in self.GEO_LIST:
-            self.download_msas()
-        if "csa" in self.GEO_LIST:
-            self.download_csas()
-        if "puma" in self.GEO_LIST:
-            self.download_pumas()
-        if "aiannh_homeland" in self.GEO_LIST:
-            self.download_aiann_homelands()
-        if "zcta" in self.GEO_LIST:
-            self.download_zctas()
+        # Call the downloader for every available geography
+        for geo in set(self.GEO_LIST) - set(self.STATE_ONLY_GEOS):
+            download = getattr(self, f"download_{geo}", None)
+            if not download or not callable(download):
+                raise NotImplementedError(f"Invalid geography type: {geo}")
+            else:
+                download()
 
     def download_everything(self):
         """
         Download 'em all.
         """
         self.download_usa()
-        for state in states.STATES:
-            if "tract" in self.GEO_LIST:
-                self.download_tracts(state.abbr)
-            if "state_legislative_district_upper" in self.GEO_LIST:
-                self.download_state_legislative_districts_upper(state.abbr)
-            if "state_legislative_district_lower" in self.GEO_LIST:
-                self.download_state_legislative_districts_lower(state.abbr)
+        for geo in set(self.GEO_LIST) & set(self.STATE_ONLY_GEOS):
+            download = getattr(self, f"download_{geo}", None)
+            if not download or not callable(download):
+                raise NotImplementedError(f"Invalid geography type: {geo}")
+            else:
+                for state in states.STATES:
+                    download(state.abbr)
 
     def _download_tables(self, api_filter, csv_suffix, geoid_function):
         """

--- a/census_data_downloader/language.py
+++ b/census_data_downloader/language.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 @register_downloader
 class HouseholdLanguageDownloader(BaseDownloader):
     YEAR_LIST = (2017, 2016)
+    GEO_LIST = ("nationwide", "state", "county", "congressional_district", "place")
     PROCESSED_TABLE_NAME = 'householdlanguage'
     UNIVERSE = "households"
     RAW_TABLE_NAME = 'C16002'

--- a/census_data_downloader/language.py
+++ b/census_data_downloader/language.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 @register_downloader
 class HouseholdLanguageDownloader(BaseDownloader):
     YEAR_LIST = (2017, 2016)
-    GEO_LIST = ("nationwide", "states", "counties", "congressional_districts", "places")
     PROCESSED_TABLE_NAME = 'householdlanguage'
     UNIVERSE = "households"
     RAW_TABLE_NAME = 'C16002'
@@ -139,6 +138,7 @@ class LanguageShortFormDownloader(BaseDownloader):
 @register_downloader
 class LanguageLongFormDownloader(BaseDownloader):
     YEAR_LIST = (2017, 2016)
+    GEO_LIST = ("nationwide", "states", "counties", "congressional_districts", "places")
     PROCESSED_TABLE_NAME = 'languagelongform'
     UNIVERSE = "population 5 years and over"
     RAW_TABLE_NAME = 'B16001'

--- a/census_data_downloader/language.py
+++ b/census_data_downloader/language.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 @register_downloader
 class HouseholdLanguageDownloader(BaseDownloader):
     YEAR_LIST = (2017, 2016)
-    GEO_LIST = ("nationwide", "state", "county", "congressional_district", "place")
+    GEO_LIST = ("nationwide", "states", "counties", "congressional_districts", "places")
     PROCESSED_TABLE_NAME = 'householdlanguage'
     UNIVERSE = "households"
     RAW_TABLE_NAME = 'C16002'

--- a/test.py
+++ b/test.py
@@ -1,5 +1,8 @@
 import pathlib
 import unittest
+from unittest import mock
+from us import states
+import collections
 import census_data_downloader
 from click.testing import CliRunner
 from census_data_downloader import cli
@@ -48,6 +51,94 @@ class CliTest(unittest.TestCase):
         self.invoke("--year", "2009", "--data-dir", "./test-data/", "yearstructurebuilt", "nationwide")
         self.invoke("--year", "2012", "--data-dir", "./test-data/", "yearstructurebuilt", "nationwide")
         self.invoke("--year", "2017", "--data-dir", "./test-data/", "yearstructurebuilt", "nationwide")
+
+
+@mock.patch('census_data_downloader.PopulationDownloader._download_tables')
+class GeographyTests(unittest.TestCase):
+    NATIONAL_GEOGRAPHIES = (
+        'us:1',
+        'state:*',
+        'congressional district:*',
+        'county:*',
+        'place:*',
+        'urban area:*',
+        'metropolitan statistical area/micropolitan statistical area:*',
+        'combined statistical area:*',
+        'public use microdata area:*',
+        'american indian area/alaska native area/hawaiian home land:*',
+        'zip code tabulation area:*'
+    )
+    STATE_GEOGRAPHIES = (
+        'state legislative district (upper chamber):*',
+        'state legislative district (lower chamber):*',
+        'tract:*'
+    )
+    
+    def test_usa(self, download_tables_mock):
+        census_data_downloader.PopulationDownloader().download_usa()
+        
+        for geo in self.NATIONAL_GEOGRAPHIES:
+            download_tables_mock.assert_any_call({'for': geo}, mock.ANY, mock.ANY)
+        
+        assert download_tables_mock.call_count == len(self.NATIONAL_GEOGRAPHIES)
+
+    def test_everything(self, download_tables_mock):
+        census_data_downloader.PopulationDownloader().download_everything()
+
+        for geo in self.NATIONAL_GEOGRAPHIES:
+            download_tables_mock.assert_any_call({'for': geo}, mock.ANY, mock.ANY)
+
+        for geo in self.STATE_GEOGRAPHIES:
+            for state in states.STATES:
+                download_tables_mock.assert_any_call({'for': geo, 'in': f'state: {state.fips}'}, mock.ANY, mock.ANY)
+
+        assert download_tables_mock.call_count == len(self.NATIONAL_GEOGRAPHIES) + len(self.STATE_GEOGRAPHIES) * len(states.STATES)
+
+    def test_usa_limited(self, download_tables_mock):
+        downloader = census_data_downloader.PopulationDownloader()
+        downloader.GEO_LIST = ("nationwide", "state", "county", "place")
+        downloader.download_usa()
+
+        download_tables_mock.assert_any_call({'for': 'us:1'}, mock.ANY, mock.ANY)
+        download_tables_mock.assert_any_call({'for': 'state:*'}, mock.ANY, mock.ANY)
+        download_tables_mock.assert_any_call({'for': 'county:*'}, mock.ANY, mock.ANY)
+        download_tables_mock.assert_any_call({'for': 'place:*'}, mock.ANY, mock.ANY)
+
+        assert download_tables_mock.call_count == 4
+
+    def test_everything_limited(self, download_tables_mock):
+        downloader = census_data_downloader.PopulationDownloader()
+        downloader.GEO_LIST = tuple(set(downloader.GEO_LIST) - set(('statelegislativedistrictupper', 'statelegislativedistrictlower')))
+        downloader.download_everything()
+
+        for geo in self.NATIONAL_GEOGRAPHIES:
+            download_tables_mock.assert_any_call({'for': geo}, mock.ANY, mock.ANY)
+
+        for state in states.STATES:
+            download_tables_mock.assert_any_call({'for': 'tract:*', 'in': f'state: {state.fips}'}, mock.ANY, mock.ANY)
+
+        assert download_tables_mock.call_count == len(self.NATIONAL_GEOGRAPHIES) + len(states.STATES)
+
+    def test_geo_methods(self, download_tables_mock):
+        downloader = census_data_downloader.PopulationDownloader()
+        downloader.GEO_LIST = ()
+
+        self.assertRaises(NotImplementedError, downloader.download_nationwide)
+        self.assertRaises(NotImplementedError, downloader.download_states)
+        self.assertRaises(NotImplementedError, downloader.download_counties)
+        self.assertRaises(NotImplementedError, downloader.download_congressional_districts)
+        self.assertRaises(NotImplementedError, downloader.download_places)
+        self.assertRaises(NotImplementedError, downloader.download_pumas)
+        self.assertRaises(NotImplementedError, downloader.download_msas)
+        self.assertRaises(NotImplementedError, downloader.download_csas)
+        self.assertRaises(NotImplementedError, downloader.download_urban_areas)
+        self.assertRaises(NotImplementedError, downloader.download_zctas)
+        self.assertRaises(NotImplementedError, downloader.download_aiann_homelands)
+        self.assertRaises(NotImplementedError, downloader.download_state_legislative_districts_lower, 'AL')
+        self.assertRaises(NotImplementedError, downloader.download_state_legislative_districts_upper, 'AL')
+        self.assertRaises(NotImplementedError, downloader.download_tracts, 'AL')
+
+        download_tables_mock.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -96,7 +96,7 @@ class GeographyTests(unittest.TestCase):
 
     def test_usa_limited(self, download_tables_mock):
         downloader = census_data_downloader.PopulationDownloader()
-        downloader.GEO_LIST = ("nationwide", "state", "county", "place")
+        downloader.GEO_LIST = ("nationwide", "states", "counties", "places")
         downloader.download_usa()
 
         download_tables_mock.assert_any_call({'for': 'us:1'}, mock.ANY, mock.ANY)
@@ -108,7 +108,7 @@ class GeographyTests(unittest.TestCase):
 
     def test_everything_limited(self, download_tables_mock):
         downloader = census_data_downloader.PopulationDownloader()
-        downloader.GEO_LIST = tuple(set(downloader.GEO_LIST) - set(('statelegislativedistrictupper', 'statelegislativedistrictlower')))
+        downloader.GEO_LIST = tuple(set(downloader.GEO_LIST) - set(('state_legislative_districts_upper', 'state_legislative_districts_lower')))
         downloader.download_everything()
 
         for geo in self.NATIONAL_GEOGRAPHIES:


### PR DESCRIPTION
This adds the ability to limit the geography for specific tables, as mentioned in #15 and #13. It uses a tuple, `GEO_LIST`, to the base class, which subclasses can override to specify a more narrow range of tables (similar to the `YEAR_LIST` already in use). If a user calls a method that isn't within the allowed geographies, it raises a `NotImplementedError`.

I also added pretty substantial tests to cover most of this implementation.

One possible improvement would be to move away from representing geographies as strings, because it can get a little confusing to switch between the `GEO_LIST` items, csv geography suffixes, and actual census API geography filters. Ideally, we would use some sort of canonical enum to store all the different representations for each geography, but I didn't want to make such a large structural change to the library without discussing it first.

This was just a first pass, so I'm happy to make any adjustments as necessary!