### PR TITLE
Adds a couple examples of calling a table class in a python script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ That's it. Mix and match tables and subcommands to get whatever you need.
 
 ### Python example
 
-Using the functionality in a Python script is easy. Import the class of the [processed table](census_data_downloader/tables) you wish to use and pass in your API key. Then call one of the download methods.
+Using the functionality in a Python script is easy. Import the class of the [processed table](https://github.com/datadesk/census-data-downloader/tree/master/census_data_downloader/tables) you wish to use and pass in your API key. Then call one of the download methods.
 
 This example brings in all state-level data from the medianhouseholdincomeblack dataset.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The library can be installed as a command-line interface that lets you download 
 $ pipenv install census-data-downloader
 ```
 
-### Usage
+### Command-line usage
 
 There's now a tool named `censusdatadownloader` ready for you.
 
@@ -84,28 +84,23 @@ $ censusdatadownloader --year 2010 medianage states
 
 That's it. Mix and match tables and subcommands to get whatever you need.
 
-### Python example
+### Python usage
 
-Using the functionality in a Python script is easy. Import the class of the [processed table](https://github.com/datadesk/census-data-downloader/tree/master/census_data_downloader/tables) you wish to use and pass in your API key. Then call one of the download methods.
+You can also download tables from Python scripts. Import the class of the [processed table](https://github.com/datadesk/census-data-downloader/tree/master/census_data_downloader/tables) you wish to retrieve and pass in your API key. Then call one of the download methods.
 
 This example brings in all state-level data from the medianhouseholdincomeblack dataset.
 
 ```python
-from census_data_downloader.tables import MedianHouseholdIncomeBlackDownloader
-
-output = MedianHouseholdIncomeBlackDownloader('e4ce29199e06153939bbb24875d73e87417ebe2e')
-
-print(output.download_states())
+>>> from census_data_downloader.tables import MedianHouseholdIncomeBlackDownloader
+>>> downloader = MedianHouseholdIncomeBlackDownloader('<YOUR KEY>')
+>>> downloader.download_states()
 ```
 
-I can specify the data directory and the years by passing in the `data_dir` and `years` keyword arguments.
+You can specify the data directory and the years by passing in the `data_dir` and `years` keyword arguments.
 
 ```python
-from census_data_downloader.tables import MedianHouseholdIncomeBlackDownloader
-
-output = MedianHouseholdIncomeBlackDownloader('e4ce29199e06153939bbb24875d73e87417ebe2e', data_dir='./', years=2016)
-
-print(output.download_states())
+>>> downloader = MedianHouseholdIncomeBlackDownloader('<YOUR KEY>', data_dir='./', years=2016)
+>>> downloader.download_states()
 ```
 
 ### Usage examples

--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ $ censusdatadownloader --year 2010 medianage states
 
 That's it. Mix and match tables and subcommands to get whatever you need.
 
+### Python example
+
+Using the functionality in a Python script is easy. Import the class of the [processed table](census_data_downloader/tables) you wish to use and pass in your API key. Then call one of the download methods.
+
+This example brings in all state-level data from the medianhouseholdincomeblack dataset.
+
+```python
+from census_data_downloader.tables import MedianHouseholdIncomeBlackDownloader
+
+output = MedianHouseholdIncomeBlackDownloader('e4ce29199e06153939bbb24875d73e87417ebe2e')
+
+print(output.download_states())
+```
+
+I can specify the data directory and the years by passing in the `data_dir` and `years` keyword arguments.
+
+```python
+from census_data_downloader.tables import MedianHouseholdIncomeBlackDownloader
+
+output = MedianHouseholdIncomeBlackDownloader('e4ce29199e06153939bbb24875d73e87417ebe2e', data_dir='./', years=2016)
+
+print(output.download_states())
+```
+
 ### Usage examples
 
 A gallery of graphics powered by our data is available on [Observable](https://observablehq.com/collection/@datadesk/u-s-census-data).


### PR DESCRIPTION
### Python example

Using the functionality in a Python script is easy. Import the class of the [processed table](https://github.com/datadesk/census-data-downloader/tree/master/census_data_downloader/tables) you wish to use and pass in your API key. Then call one of the download methods.

This example brings in all state-level data from the medianhouseholdincomeblack dataset.

```python
from census_data_downloader.tables import MedianHouseholdIncomeBlackDownloader

output = MedianHouseholdIncomeBlackDownloader('e4ce29199e06153939bbb24875d73e87417ebe2e')

print(output.download_states())
```

I can specify the data directory and the years by passing in the `data_dir` and `years` keyword arguments.

```python
from census_data_downloader.tables import MedianHouseholdIncomeBlackDownloader

output = MedianHouseholdIncomeBlackDownloader('e4ce29199e06153939bbb24875d73e87417ebe2e', data_dir='./', years=2016)

print(output.download_states())
```