### PR TITLE
Fix markdown bug

### DIFF
--- a/TABLES.md
+++ b/TABLES.md
@@ -12,299 +12,299 @@ All of the U.S. Census tables processed by this library.
 </thead>
 <tbody>
     
-        <tr>
-            <td>age</td>
-            <td>total population</td>
-            <td>B01001</td>
-        </tr>
-    
-        <tr>
-            <td>ancestry</td>
-            <td>people reporting single ancestry</td>
-            <td>B04004</td>
-        </tr>
-    
-        <tr>
-            <td>classofworker</td>
-            <td>civilian employed population 16 years and over</td>
-            <td>B24080</td>
-        </tr>
-    
-        <tr>
-            <td>education</td>
-            <td>population 25 Years and Over</td>
-            <td>B15002</td>
-        </tr>
-    
-        <tr>
-            <td>employmentstatus</td>
-            <td>population 16 years and over</td>
-            <td>B23025</td>
-        </tr>
-    
-        <tr>
-            <td>foreignborn</td>
-            <td>total population</td>
-            <td>B05002</td>
-        </tr>
-    
-        <tr>
-            <td>citizenstatus</td>
-            <td>total population</td>
-            <td>B05001</td>
-        </tr>
-    
-        <tr>
-            <td>medianmonthlyhousingcosts</td>
-            <td>occupied housing units with monthly housing costs</td>
-            <td>B25105</td>
-        </tr>
-    
-        <tr>
-            <td>medianhousingvalue</td>
-            <td>owner-occupied housing units</td>
-            <td>B25077</td>
-        </tr>
-    
-        <tr>
-            <td>mediangrossrent</td>
-            <td>renter-occupied housing units paying cash rent</td>
-            <td>B25064</td>
-        </tr>
-    
-        <tr>
-            <td>tenure</td>
-            <td>occupied housing units</td>
-            <td>B25003</td>
-        </tr>
-    
-        <tr>
-            <td>tenurelatino</td>
-            <td>occupied housing units</td>
-            <td>B25003I</td>
-        </tr>
-    
-        <tr>
-            <td>tenurewhite</td>
-            <td>occupied housing units</td>
-            <td>B25003H</td>
-        </tr>
-    
-        <tr>
-            <td>tenureblack</td>
-            <td>occupied housing units</td>
-            <td>B25003B</td>
-        </tr>
-    
-        <tr>
-            <td>tenureasian</td>
-            <td>occupied housing units</td>
-            <td>B25003D</td>
-        </tr>
-    
-        <tr>
-            <td>householdincome</td>
-            <td>households</td>
-            <td>B19001</td>
-        </tr>
-    
-        <tr>
-            <td>householdincomelatino</td>
-            <td>households</td>
-            <td>B19001I</td>
-        </tr>
-    
-        <tr>
-            <td>householdincomewhite</td>
-            <td>households</td>
-            <td>B19001H</td>
-        </tr>
-    
-        <tr>
-            <td>householdincomeblack</td>
-            <td>households</td>
-            <td>B19001B</td>
-        </tr>
-    
-        <tr>
-            <td>householdincomeasian</td>
-            <td>households</td>
-            <td>B19001D</td>
-        </tr>
-    
-        <tr>
-            <td>internet</td>
-            <td>households</td>
-            <td>B28002</td>
-        </tr>
-    
-        <tr>
-            <td>householdlanguage</td>
-            <td>households</td>
-            <td>C16002</td>
-        </tr>
-    
-        <tr>
-            <td>languageshortform</td>
-            <td>population 5 years and over</td>
-            <td>C16001</td>
-        </tr>
-    
-        <tr>
-            <td>languagelongform</td>
-            <td>population 5 years and over</td>
-            <td>B16001</td>
-        </tr>
-    
-        <tr>
-            <td>latino</td>
-            <td>total population</td>
-            <td>B03001</td>
-        </tr>
-    
-        <tr>
-            <td>medianage</td>
-            <td>total population</td>
-            <td>B01002</td>
-        </tr>
-    
-        <tr>
-            <td>medianhouseholdincome</td>
-            <td>households</td>
-            <td>B19013</td>
-        </tr>
-    
-        <tr>
-            <td>medianhouseholdincomelatino</td>
-            <td>households</td>
-            <td>B19013I</td>
-        </tr>
-    
-        <tr>
-            <td>medianhouseholdincomewhite</td>
-            <td>households</td>
-            <td>B19013H</td>
-        </tr>
-    
-        <tr>
-            <td>medianhouseholdincomeblack</td>
-            <td>households</td>
-            <td>B19013B</td>
-        </tr>
-    
-        <tr>
-            <td>medianhouseholdincomeasian</td>
-            <td>households</td>
-            <td>B19013D</td>
-        </tr>
-    
-        <tr>
-            <td>mobility</td>
-            <td>population 1 year and over</td>
-            <td>B07003</td>
-        </tr>
-    
-        <tr>
-            <td>mobilitybysex</td>
-            <td>population 1 year and over</td>
-            <td>B07003</td>
-        </tr>
-    
-        <tr>
-            <td>mobilitywhite</td>
-            <td>population 1 year and over</td>
-            <td>B07004H</td>
-        </tr>
-    
-        <tr>
-            <td>mobilityblack</td>
-            <td>population 1 year and over</td>
-            <td>B07004B</td>
-        </tr>
-    
-        <tr>
-            <td>mobilityasian</td>
-            <td>population 1 year and over</td>
-            <td>B07004D</td>
-        </tr>
-    
-        <tr>
-            <td>mobilitylatino</td>
-            <td>population 1 year and over</td>
-            <td>B07004I</td>
-        </tr>
-    
-        <tr>
-            <td>mobilitybycitizenship</td>
-            <td>population 1 year and over</td>
-            <td>B07007</td>
-        </tr>
-    
-        <tr>
-            <td>population</td>
-            <td>total population</td>
-            <td>B01003</td>
-        </tr>
-    
-        <tr>
-            <td>poverty</td>
-            <td>population for whom poverty status is determined</td>
-            <td>B17001</td>
-        </tr>
-    
-        <tr>
-            <td>povertystatusbygender</td>
-            <td>population for whom poverty status is determined</td>
-            <td>B17001</td>
-        </tr>
-    
-        <tr>
-            <td>povertystatusbyage</td>
-            <td>population for whom poverty status is determined</td>
-            <td>B17001</td>
-        </tr>
-    
-        <tr>
-            <td>povertylatino</td>
-            <td>Latino population for whom poverty status is determined</td>
-            <td>B17001I</td>
-        </tr>
-    
-        <tr>
-            <td>povertywhite</td>
-            <td>white population for whom poverty status is determined</td>
-            <td>B17001A</td>
-        </tr>
-    
-        <tr>
-            <td>povertyblack</td>
-            <td>Black population for whom poverty status is determined</td>
-            <td>B17001B</td>
-        </tr>
-    
-        <tr>
-            <td>povertyasian</td>
-            <td>Asian population for whom poverty status is determined</td>
-            <td>B17001D</td>
-        </tr>
-    
-        <tr>
-            <td>race</td>
-            <td>total population</td>
-            <td>B03002</td>
-        </tr>
-    
-        <tr>
-            <td>aianaloneorincombo</td>
-            <td>people who are american indian or alaska native alone or in combination with one or more races</td>
-            <td>B02010</td>
-        </tr>
-    
-        <tr>
-            <td>asian</td>
-            <td>total asian alone population</td>
-            <td>B02015</td>
-        </tr>
-    
+<tr>
+    <td>age</td>
+    <td>total population</td>
+    <td>B01001</td>
+</tr>
+
+<tr>
+    <td>ancestry</td>
+    <td>people reporting single ancestry</td>
+    <td>B04004</td>
+</tr>
+
+<tr>
+    <td>classofworker</td>
+    <td>civilian employed population 16 years and over</td>
+    <td>B24080</td>
+</tr>
+
+<tr>
+    <td>education</td>
+    <td>population 25 Years and Over</td>
+    <td>B15002</td>
+</tr>
+
+<tr>
+    <td>employmentstatus</td>
+    <td>population 16 years and over</td>
+    <td>B23025</td>
+</tr>
+
+<tr>
+    <td>foreignborn</td>
+    <td>total population</td>
+    <td>B05002</td>
+</tr>
+
+<tr>
+    <td>citizenstatus</td>
+    <td>total population</td>
+    <td>B05001</td>
+</tr>
+
+<tr>
+    <td>medianmonthlyhousingcosts</td>
+    <td>occupied housing units with monthly housing costs</td>
+    <td>B25105</td>
+</tr>
+
+<tr>
+    <td>medianhousingvalue</td>
+    <td>owner-occupied housing units</td>
+    <td>B25077</td>
+</tr>
+
+<tr>
+    <td>mediangrossrent</td>
+    <td>renter-occupied housing units paying cash rent</td>
+    <td>B25064</td>
+</tr>
+
+<tr>
+    <td>tenure</td>
+    <td>occupied housing units</td>
+    <td>B25003</td>
+</tr>
+
+<tr>
+    <td>tenurelatino</td>
+    <td>occupied housing units</td>
+    <td>B25003I</td>
+</tr>
+
+<tr>
+    <td>tenurewhite</td>
+    <td>occupied housing units</td>
+    <td>B25003H</td>
+</tr>
+
+<tr>
+    <td>tenureblack</td>
+    <td>occupied housing units</td>
+    <td>B25003B</td>
+</tr>
+
+<tr>
+    <td>tenureasian</td>
+    <td>occupied housing units</td>
+    <td>B25003D</td>
+</tr>
+
+<tr>
+    <td>householdincome</td>
+    <td>households</td>
+    <td>B19001</td>
+</tr>
+
+<tr>
+    <td>householdincomelatino</td>
+    <td>households</td>
+    <td>B19001I</td>
+</tr>
+
+<tr>
+    <td>householdincomewhite</td>
+    <td>households</td>
+    <td>B19001H</td>
+</tr>
+
+<tr>
+    <td>householdincomeblack</td>
+    <td>households</td>
+    <td>B19001B</td>
+</tr>
+
+<tr>
+    <td>householdincomeasian</td>
+    <td>households</td>
+    <td>B19001D</td>
+</tr>
+
+<tr>
+    <td>internet</td>
+    <td>households</td>
+    <td>B28002</td>
+</tr>
+
+<tr>
+    <td>householdlanguage</td>
+    <td>households</td>
+    <td>C16002</td>
+</tr>
+
+<tr>
+    <td>languageshortform</td>
+    <td>population 5 years and over</td>
+    <td>C16001</td>
+</tr>
+
+<tr>
+    <td>languagelongform</td>
+    <td>population 5 years and over</td>
+    <td>B16001</td>
+</tr>
+
+<tr>
+    <td>latino</td>
+    <td>total population</td>
+    <td>B03001</td>
+</tr>
+
+<tr>
+    <td>medianage</td>
+    <td>total population</td>
+    <td>B01002</td>
+</tr>
+
+<tr>
+    <td>medianhouseholdincome</td>
+    <td>households</td>
+    <td>B19013</td>
+</tr>
+
+<tr>
+    <td>medianhouseholdincomelatino</td>
+    <td>households</td>
+    <td>B19013I</td>
+</tr>
+
+<tr>
+    <td>medianhouseholdincomewhite</td>
+    <td>households</td>
+    <td>B19013H</td>
+</tr>
+
+<tr>
+    <td>medianhouseholdincomeblack</td>
+    <td>households</td>
+    <td>B19013B</td>
+</tr>
+
+<tr>
+    <td>medianhouseholdincomeasian</td>
+    <td>households</td>
+    <td>B19013D</td>
+</tr>
+
+<tr>
+    <td>mobility</td>
+    <td>population 1 year and over</td>
+    <td>B07003</td>
+</tr>
+
+<tr>
+    <td>mobilitybysex</td>
+    <td>population 1 year and over</td>
+    <td>B07003</td>
+</tr>
+
+<tr>
+    <td>mobilitywhite</td>
+    <td>population 1 year and over</td>
+    <td>B07004H</td>
+</tr>
+
+<tr>
+    <td>mobilityblack</td>
+    <td>population 1 year and over</td>
+    <td>B07004B</td>
+</tr>
+
+<tr>
+    <td>mobilityasian</td>
+    <td>population 1 year and over</td>
+    <td>B07004D</td>
+</tr>
+
+<tr>
+    <td>mobilitylatino</td>
+    <td>population 1 year and over</td>
+    <td>B07004I</td>
+</tr>
+
+<tr>
+    <td>mobilitybycitizenship</td>
+    <td>population 1 year and over</td>
+    <td>B07007</td>
+</tr>
+
+<tr>
+    <td>population</td>
+    <td>total population</td>
+    <td>B01003</td>
+</tr>
+
+<tr>
+    <td>poverty</td>
+    <td>population for whom poverty status is determined</td>
+    <td>B17001</td>
+</tr>
+
+<tr>
+    <td>povertystatusbygender</td>
+    <td>population for whom poverty status is determined</td>
+    <td>B17001</td>
+</tr>
+
+<tr>
+    <td>povertystatusbyage</td>
+    <td>population for whom poverty status is determined</td>
+    <td>B17001</td>
+</tr>
+
+<tr>
+    <td>povertylatino</td>
+    <td>Latino population for whom poverty status is determined</td>
+    <td>B17001I</td>
+</tr>
+
+<tr>
+    <td>povertywhite</td>
+    <td>white population for whom poverty status is determined</td>
+    <td>B17001A</td>
+</tr>
+
+<tr>
+    <td>povertyblack</td>
+    <td>Black population for whom poverty status is determined</td>
+    <td>B17001B</td>
+</tr>
+
+<tr>
+    <td>povertyasian</td>
+    <td>Asian population for whom poverty status is determined</td>
+    <td>B17001D</td>
+</tr>
+
+<tr>
+    <td>race</td>
+    <td>total population</td>
+    <td>B03002</td>
+</tr>
+
+<tr>
+    <td>aianaloneorincombo</td>
+    <td>people who are american indian or alaska native alone or in combination with one or more races</td>
+    <td>B02010</td>
+</tr>
+
+<tr>
+    <td>asian</td>
+    <td>total asian alone population</td>
+    <td>B02015</td>
+</tr>
+
 </tbody>
 </table>


### PR DESCRIPTION
The indent for the `tbody` was causing it to be rendered as raw markup/code. This change makes the markdown format correctly.