### PR TITLE
Add README as long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
+from os import path
 from setuptools import setup
 
-
+# Read the contents of the README file
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+    
 setup(
     name='census-data-downloader',
     version='0.0.27',
     description="Download U.S. census data and reformat it for humans",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Los Angeles Times Data Desk',
     author_email='datadesk@latimes.com',
     url='http://www.github.com/datadesk/census-data-downloader',


### PR DESCRIPTION
Read the contents of `README.md` and set as the `long_description` argument to `setup()`. This allows displaying the README contents in PyPI. The pattern for doing this is from [Making a PyPI-friendly README](https://packaging.python.org/guides/making-a-pypi-friendly-readme/).

Addresses #42